### PR TITLE
Add controls to pack contents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ compileJava {
 minecraft {
     version = "1.12.2-14.23.5.2847"
     runDir = "run"
-	replaceIn 'src/main/java/astrotibs/villagenames/utility/Reference.java'
+	replaceIn 'com/is/mtc/util/Reference.java'
 	replace '@VERSION@', project.version
     mappings = "snapshot_20171003"
 }

--- a/src/main/java/com/is/mtc/MineTradingCards.java
+++ b/src/main/java/com/is/mtc/MineTradingCards.java
@@ -12,6 +12,9 @@ import com.is.mtc.displayer_mono.MonoDisplayerBlockTileEntity;
 import com.is.mtc.handler.DropHandler;
 import com.is.mtc.handler.GuiHandler;
 import com.is.mtc.init.MTCItems;
+import com.is.mtc.pack.PackItemEdition;
+import com.is.mtc.pack.PackItemRarity;
+import com.is.mtc.pack.PackItemStandard;
 import com.is.mtc.packet.MTCMessage;
 import com.is.mtc.packet.MTCMessageHandler;
 import com.is.mtc.packet.MTCMessageRequestUpdateDisplayer;
@@ -67,6 +70,7 @@ public class MineTradingCards {
 	public static final String CONFIG_CAT_COLORS = "colors";
 	public static final String CONFIG_CAT_DROPS = "drops";
 	public static final String CONFIG_CAT_LOGS = "logs";
+	public static final String CONFIG_CAT_PACK_CONTENTS = "pack contents";
 	public static final String CONFIG_CAT_RECIPES = "recipes";
 	public static final String CONFIG_CAT_UPDATES = "updates";
 	public static final String CONFIG_CAT_VILLAGERS = "villagers";
@@ -108,6 +112,16 @@ public class MineTradingCards {
 			return new ItemStack(MTCItems.packStandard);
 		}
 	};
+	
+	private static final String cardPackDistributionDescription(String rarity, boolean allowNx) {
+		return "Number and type of cards dropped when a "+rarity+" pack is opened. Entries are of the form:"
+		+ "\nNxW:W:W:W:W" + (allowNx ? " or Nx" : "")
+		+ "\nN is the number of cards added from this row. It can be an integer (e.g. 5) or it can be a float like 3.4 (40% of the time 4 will be generated; otherwise 3 will)."
+		+ "\nx is just the letter x. Leave this as is."
+		+ "\nW:W:W:W:W:W is a distribution of rarity weights representing Com:Unc:Rar:Anc:Leg. Each card generated from this row will be drawn from this distribution. "
+		+ "For example: 0:1:0:0:1 has an equal chance of being an Uncommon or Legendary card. 2:1:1:1:1 can be any rarity, but is twice as likely to be "+rarity+" as the other rarities."
+		+ (allowNx ? "\nFor Nx formatting, the weighting portion is omitted. All cards genrerated are "+rarity+", because this is a "+rarity+" pack. N can be an integer or a float, as explained above." : "");
+	}
 	
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
@@ -235,8 +249,16 @@ public class MineTradingCards {
 				+ "\nThis list applies even if \"can_drop\" is false."
 				);
 		
-		// === Logging ===
-		Logs.ENABLE_DEV_LOGS = config.getBoolean("devlog_enabled", CONFIG_CAT_LOGS, false, "Enable developer logs");
+		
+		// === Pack contents ===
+		PackItemRarity.COMMON_PACK_CONTENT = config.getStringList("common_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.COMMON_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Common", true));
+		PackItemRarity.UNCOMMON_PACK_CONTENT = config.getStringList("uncommon_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.UNCOMMON_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Uncommon", true));
+		PackItemRarity.RARE_PACK_CONTENT = config.getStringList("rare_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.RARE_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Rare", true));
+		PackItemRarity.ANCIENT_PACK_CONTENT = config.getStringList("ancient_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.ANCIENT_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Ancient", true));
+		PackItemRarity.LEGENDARY_PACK_CONTENT = config.getStringList("legendary_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.LEGENDARY_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Legendary", true));
+		PackItemStandard.STANDARD_PACK_CONTENT = config.getStringList("standard_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemStandard.STANDARD_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Standard", false));
+		PackItemEdition.EDITION_PACK_CONTENT = config.getStringList("edition_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemStandard.STANDARD_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Edition", false));
+		
 		
 		// === Villager ===
 		MineTradingCardVillagers.CARD_MASTER_TRADE_LIST = config.getStringList("card_master_trades", CONFIG_CAT_VILLAGERS, MineTradingCardVillagers.CARD_MASTER_TRADE_LIST_DEFAULT,
@@ -259,6 +281,9 @@ public class MineTradingCards {
 				);
 		CardMasterHomeHandler.SHOP_WEIGHT = config.getInt("card_shop_weight", CONFIG_CAT_VILLAGERS, 5, 0, 100, "Weighting for selection when villages generate. Farms and wood huts are 3, church is 20.");
 		CardMasterHomeHandler.SHOP_MAX_NUMBER = config.getInt("card_shop_max_number", CONFIG_CAT_VILLAGERS, 1, 0, 32, "Maximum number of card master shops that can spawn per village");
+
+		// === Logging ===
+		Logs.ENABLE_DEV_LOGS = config.getBoolean("devlog_enabled", CONFIG_CAT_LOGS, false, "Enable developer logs");
 		
 		// === Update Checker ===
 		ENABLE_UPDATE_CHECKER = config.getBoolean("enable_update_checker", CONFIG_CAT_UPDATES, true, "Displays a client-side chat message on login if there's an update available.");

--- a/src/main/java/com/is/mtc/card/CardItem.java
+++ b/src/main/java/com/is/mtc/card/CardItem.java
@@ -35,7 +35,9 @@ public class CardItem extends Item {//implements IItemColor {
 	private static final int MAX_DESC_LENGTH = 42;
 
 	private int rarity;
-
+	
+	public static final int[] CARD_RARITY_ARRAY = new int[] {Rarity.COMMON, Rarity.UNCOMMON, Rarity.RARE, Rarity.ANCIENT, Rarity.LEGENDARY};
+	
 	public CardItem(int r) {
 		setUnlocalizedName(PREFIX + Rarity.toString(r).toLowerCase());
 		setRegistryName(PREFIX + Rarity.toString(r).toLowerCase());

--- a/src/main/java/com/is/mtc/pack/PackItemBase.java
+++ b/src/main/java/com/is/mtc/pack/PackItemBase.java
@@ -18,7 +18,7 @@ import net.minecraft.world.World;
 
 public class PackItemBase extends Item {
 
-	protected static final int RETRY = 5;
+	protected static final int RETRY = 50;
 
 	public PackItemBase() {
 		setCreativeTab(MineTradingCards.MODTAB);

--- a/src/main/java/com/is/mtc/pack/PackItemStandard.java
+++ b/src/main/java/com/is/mtc/pack/PackItemStandard.java
@@ -1,10 +1,12 @@
 package com.is.mtc.pack;
 
 import java.util.ArrayList;
+import java.util.Random;
 
 import com.is.mtc.MineTradingCards;
+import com.is.mtc.card.CardItem;
 import com.is.mtc.root.Logs;
-import com.is.mtc.root.Rarity;
+import com.is.mtc.util.Functions;
 
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.entity.player.EntityPlayer;
@@ -12,46 +14,77 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class PackItemStandard extends PackItemBase {
-
-	private static final int[] cCount = {7, 2, 1};
-	private static final int[] rWeight = {25, 29, 30};
-	private static final int rtWeight = rWeight[2];
-
+	
+	public static final String[] STANDARD_PACK_CONTENT_DEFAULT = new String[] {
+			"7x1:0:0:0:0",
+			"2x0:1:0:0:0",
+			"1x0:0:25:4:1",
+	};
+	public static String[] STANDARD_PACK_CONTENT = STANDARD_PACK_CONTENT_DEFAULT;
+	
 	public PackItemStandard() {
 		setUnlocalizedName("item_pack_standard");
 		setRegistryName("item_pack_standard");
-		//setTextureName(MineTradingCards.MODID + ":item_pack_standard");
 	}
 
 	@Override
 	public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
+		if (world.isRemote) {return new ActionResult<>(EnumActionResult.SUCCESS, player.getHeldItem(hand));} // Don't do this on the client side
+		
 		ArrayList<String> created;
-		int i;
-
-		if (world.isRemote) {
-			return new ActionResult<>(EnumActionResult.SUCCESS, player.getHeldItem(hand));
+		Random random = world.rand;
+		
+		// Figure out how many of each card rarity to create
+		
+		int[] card_set_to_create = new int[] {0,0,0,0,0}; // Set of cards that will come out of the pack
+		
+		for (String entry : STANDARD_PACK_CONTENT)
+		{
+			try {
+				double[] card_weighted_dist = new double[] {0,0,0,0,0}; // Distribution used when a card is randomized
+				
+				// Split entry
+				String[] split_entry = entry.toLowerCase().trim().split("x");
+				
+				float count = MathHelper.clamp(Float.parseFloat(split_entry[0]), 0F, 64F);
+				int drop_count_characteristic = (int) count;
+				float drop_count_mantissa = count % 1;
+				
+				String[] distribution_split = split_entry[1].split(":");
+				
+				for (int i=0; i<distribution_split.length; i++) {
+					card_weighted_dist[i]=Integer.parseInt(distribution_split[i].trim());
+				}
+				
+				// Repeat for the number of cards prescribed
+				for (int i=0; i<drop_count_characteristic + (random.nextFloat()<drop_count_mantissa ? 1 : 0); i++)
+				{
+					Object chosen_rarity = Functions.weightedRandom(CardItem.CARD_RARITY_ARRAY, card_weighted_dist, random);
+					
+					if (chosen_rarity!=null) {
+						card_set_to_create[(Integer)chosen_rarity]++;
+					}
+				}
+			}
+			catch (Exception e) {
+				Logs.errLog("Something went wrong parsing standard_pack_contents line: " + entry);
+			}
 		}
 
+		// Actually create the cards
+		
 		created = new ArrayList<String>();
-		createCards(Rarity.COMMON, cCount[Rarity.COMMON], created, world.rand);
-		createCards(Rarity.UNCOMMON, cCount[Rarity.UNCOMMON], created, world.rand);
-
-		i = world.rand.nextInt(rtWeight);
-		if (i < rWeight[0]) {
-			createCards(Rarity.RARE, cCount[Rarity.RARE], created, world.rand);
+		
+		for (int rarity : CardItem.CARD_RARITY_ARRAY) {
+			createCards(rarity, card_set_to_create[rarity], created, world.rand);
 		}
-		else if (i < rWeight[1]) {
-			createCards(Rarity.ANCIENT, cCount[Rarity.RARE], created, world.rand);
-		}
-		else if (i < rWeight[2]) {
-			createCards(Rarity.LEGENDARY, cCount[Rarity.RARE], created, world.rand);
-		}
-
+		
 		if (created.size() > 0) {
 			for (String cdwd : created) {
 				spawnCard(player, world, cdwd);
@@ -64,7 +97,6 @@ public class PackItemStandard extends PackItemBase {
 
 		return new ActionResult<>(EnumActionResult.SUCCESS, player.getHeldItem(hand));
 	}
-	
 	
 	// === ICON LAYERING AND COLORIZATION === //
 	/** 


### PR DESCRIPTION
Here I've added config options that lets users specify how many of which cards can appear in which pack types. Since there is a precedence for a pack type that has at least one randomized card type in it (i.e. Standard), I have added the flexibility for a weighted card choice.

All default values mirror the already-existing pack content values.

I've also increased `PackItemBase.RETRY` to 50 because Java is pretty fast and can probably get away with re-rolling up to 50 times to search for a non-duplicate.

Edited a small mistake: now the version's `build.grade` will properly replace the version number on build.