### PR TITLE
Card assets moved from mtc/assets to a resourcepack 

### DIFF
--- a/src/main/java/com/is/mtc/MineTradingCards.java
+++ b/src/main/java/com/is/mtc/MineTradingCards.java
@@ -69,6 +69,7 @@ public class MineTradingCards {
 	
 	// The directories that MTC works with
 	private static String DATA_DIR = "";
+	public static String ASSET_DIR = "";
 	public static String CONF_DIR = "";
 	
 	// Configuration stuff
@@ -104,7 +105,7 @@ public class MineTradingCards {
 	public static final String COLOR_TOOLTIP_1 = "Tooltip color for ";
 	public static final String COLOR_TOOLTIP_2 = " cards, using \"friendly\" Minecraft color name";
 	
-	// Mod intercompatibility stuff
+	// Mod compatibility stuff
 	public static boolean hasVillageNamesInstalled = false;
 	
 	// The proxy, either a combined client or a dedicated server
@@ -128,7 +129,7 @@ public class MineTradingCards {
 		+ "For example: 0:1:0:0:1 has an equal chance of being an Uncommon or Legendary card. 2:1:1:1:1 can be any rarity, but is twice as likely to be "+rarity+" as the other rarities."
 		+ (allowNx ? "\nFor Nx formatting, the weighting portion is omitted. All cards genrerated are "+rarity+", because this is a "+rarity+" pack. N can be an integer or a float, as explained above." : "");
 	}
-	
+
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
 
@@ -137,6 +138,7 @@ public class MineTradingCards {
         
 		// Gets the config and reads the cards, and runs the preinitialisation from the proxy
 		DATA_DIR = event.getModConfigurationDirectory().getParentFile().getAbsolutePath().replace('\\', '/') + "/mtc/";
+		ASSET_DIR = event.getModConfigurationDirectory().getParentFile().getAbsolutePath().replace('\\', '/') + "/mtc/";
 		CONF_DIR = event.getModConfigurationDirectory().getAbsolutePath().replace('\\', '/') + '/';
 		MTCItems.init();
 

--- a/src/main/java/com/is/mtc/MineTradingCards.java
+++ b/src/main/java/com/is/mtc/MineTradingCards.java
@@ -135,10 +135,9 @@ public class MineTradingCards {
 
 		// Display 
         event.getModMetadata().logoFile = "mtc_banner.png";
-        
+
 		// Gets the config and reads the cards, and runs the preinitialisation from the proxy
-		DATA_DIR = event.getModConfigurationDirectory().getParentFile().getAbsolutePath().replace('\\', '/') + "/mtc/";
-		ASSET_DIR = event.getModConfigurationDirectory().getParentFile().getAbsolutePath().replace('\\', '/') + "/mtc/";
+		DATA_DIR = event.getModConfigurationDirectory().getParentFile().getAbsolutePath().replace('\\', '/') + "/resourcepacks/mtc/";
 		CONF_DIR = event.getModConfigurationDirectory().getAbsolutePath().replace('\\', '/') + '/';
 		MTCItems.init();
 

--- a/src/main/java/com/is/mtc/binder/BinderItemGuiContainer.java
+++ b/src/main/java/com/is/mtc/binder/BinderItemGuiContainer.java
@@ -266,12 +266,11 @@ public class BinderItemGuiContainer extends GuiContainer {
 				if (Tools.isValidCard(stack)) { // Is a valid itemstack for card
 					CardStructure cStruct = Databank.getCardByCDWD(stack.getTagCompound().getString("cdwd"));
 
-					if (cStruct != null && cStruct.getDynamicTexture() != null) { // Card data and illustration are correct
-						cStruct.preloadResource(mc.getTextureManager(), stack.getTagCompound().getInteger("assetnumber"));
-						if (cStruct.getResourceLocation() != null) {
-							mc.getTextureManager().bindTexture(cStruct.getResourceLocation());
+					//TODO check if card texture file exists
+					if (cStruct != null && cStruct.getAssetLocation() != null) { // Card data and illustration are correct
+							//TODO load image from file when its called
+							mc.getTextureManager().bindTexture(cStruct.getAssetLocation());
 							drawTexturedModalRect((int) drawPos.x + 8 + j * 58, (int) drawPos.y + 8 + i * 64);
-						}
 					} else {
 						drawString(fontRenderer, "s" + (x + 1),
 								(int) drawPos.x + 8 + j * 58, (int) drawPos.y + 8 + i * 64, 0xFFFFFF);

--- a/src/main/java/com/is/mtc/card/CardItem.java
+++ b/src/main/java/com/is/mtc/card/CardItem.java
@@ -49,15 +49,6 @@ public class CardItem extends Item {//implements IItemColor {
 	public int getCardRarity() {
 		return rarity;
 	}
-	
-	public static ItemStack applyCDWDtoStack(ItemStack stack, CardStructure cStruct, Random random) {
-		NBTTagCompound nbtTag = stack.getTagCompound();
-		nbtTag.setString("cdwd", cStruct.getCDWD());
-		if (cStruct.getAssetPath().size() > 0) {
-			nbtTag.setInteger("assetnumber", Tools.randInt(0, cStruct.getAssetPath().size(), random));
-		}
-		return stack;
-	}
 
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
@@ -103,7 +94,6 @@ public class CardItem extends Item {//implements IItemColor {
 						popoffStack.setTagCompound(new NBTTagCompound());
 					}
 					popoffStack.setCount(1);
-					popoffStack = applyCDWDtoStack(popoffStack, cStruct, world.rand);
 					
 					EntityItem dropped_card = player.entityDropItem(popoffStack, 1);
 					dropped_card.setPickupDelay(0);
@@ -112,23 +102,12 @@ public class CardItem extends Item {//implements IItemColor {
 						stack.shrink(1);
 					}
 				}
-				else { // Add data to the singleton "empty" card 
-					stack = applyCDWDtoStack(stack, cStruct, world.rand);
-				}
 			} else {
 				Logs.errLog("Unable to generate a card of this rarity: " + Rarity.toString(rarity));
 			}
 		}
 
 		NBTTagCompound nbtTag = stack.getTagCompound();
-		if (!nbtTag.hasKey("assetnumber")) {
-			CardStructure cStruct = Databank.getCardByCDWD(nbtTag.getString("cdwd"));
-			if (cStruct != null) {
-				if (cStruct.getAssetPath().size() > 0) {
-					nbtTag.setInteger("assetnumber", Tools.randInt(0, cStruct.getAssetPath().size(), world.rand));
-				}
-			}
-		}
 
 		return new ActionResult<>(EnumActionResult.SUCCESS, stack);
 	}

--- a/src/main/java/com/is/mtc/card/CardItemInterface.java
+++ b/src/main/java/com/is/mtc/card/CardItemInterface.java
@@ -22,12 +22,11 @@ public class CardItemInterface extends GuiScreen {
 	@Override
 	public void drawScreen(int mouseX, int mouseY, float partialTicks) {
 		double dpx = (width - CardItemInterface.UI_WIDTH) / 2, dpy = (height - CardItemInterface.UI_HEIGHT) / 2;
-
-		cStruct.preloadResource(mc.getTextureManager(), stack.getTagCompound().getInteger("assetnumber"));
 		//System.out.println(cStruct.getResourceLocation());
 		drawDefaultBackground();
-		if (cStruct.getResourceLocation() != null) {
-			mc.getTextureManager().bindTexture(cStruct.getResourceLocation());
+		if (cStruct.getAssetLocation() != null) {
+			//TODO this should look for the card image when the card is used
+			mc.getTextureManager().bindTexture(cStruct.getAssetLocation());
 			//mc.getTextureManager().getTexture(cStruct.getResourceLocation());
 
 			drawTexturedModalRect(dpx, dpy, CardItemInterface.UI_WIDTH, CardItemInterface.UI_HEIGHT);

--- a/src/main/java/com/is/mtc/data_manager/CDFCardStructure.java
+++ b/src/main/java/com/is/mtc/data_manager/CDFCardStructure.java
@@ -1,18 +1,19 @@
 package com.is.mtc.data_manager;
 
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.is.mtc.*;
 import com.is.mtc.root.Tools;
 
 public class CDFCardStructure {
 
 	private String id, edition;
 	private String rarity;
-
+	private String illustrationPath;
 	private String name, category, /*assetPath, */
 			description;
-	private List<String> assetPath;
 	private int weight;
 
 	public CDFCardStructure() {
@@ -22,8 +23,8 @@ public class CDFCardStructure {
 
 		name = "";
 		category = "";
-		assetPath = new ArrayList<>();
 		weight = 0;
+		//TODO try to find the asset file and if found then assign to the assetLocation File
 	}
 
 	public void giveArgument(String argument) {
@@ -51,7 +52,7 @@ public class CDFCardStructure {
 		else if (args[0].equals("illustrationpath") || args[0].equals("asset")) {
 			String[] tempPathList = args[1].split(":");
 			for (String asset : tempPathList) {
-				assetPath.add(Tools.clean(asset));
+				illustrationPath = asset;
 			}
 		} else if (args[0].equals("description"))
 			description = args[1];
@@ -81,11 +82,11 @@ public class CDFCardStructure {
 		return weight;
 	}
 
-	public List<String> getAssetPath() {
-		return assetPath;
-	}
-
 	public String getDescription() {
 		return description;
+	}
+
+	public String getIllustrationPath() {
+		return illustrationPath;
 	}
 }

--- a/src/main/java/com/is/mtc/data_manager/DataLoader.java
+++ b/src/main/java/com/is/mtc/data_manager/DataLoader.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.util.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;

--- a/src/main/java/com/is/mtc/data_manager/DataLoader.java
+++ b/src/main/java/com/is/mtc/data_manager/DataLoader.java
@@ -131,7 +131,7 @@ public class DataLoader {
 
 					cStruct = new CardStructure(cdfStruct.getId(), cdfStruct.getEdition(), cdfStruct.getRarity());
 
-					if (!cStruct.setSecondaryInput(cdfStruct.getName(), cdfStruct.getCategory(), cdfStruct.getWeight(), cdfStruct.getAssetPath(), cdfStruct.getDescription()))
+					if (!cStruct.setSecondaryInput(file.toPath(), cdfStruct.getName(), cdfStruct.getCategory(), cdfStruct.getWeight(), cdfStruct.getIllustrationPath(), cdfStruct.getDescription()))
 						Logs.errLog("Concerned card file: " + file.getName());
 
 					if (!Databank.registerACard(cStruct))
@@ -149,9 +149,9 @@ public class DataLoader {
 
 					reader.close();
 
-					CardStructure cStruct = new CardStructure(head.get("id"), head.get("edition"), head.get("rarity"));
+					CardStructure cStruct = new CardStructure(file.toPath(), head.get("id"), head.get("edition"), head.get("rarity"));
 
-					if (!cStruct.setSecondaryInput(head.get("name"), head.get("category"), head.get("weight"), head.get("asset"), head.get("description")))
+					if (!cStruct.setSecondaryInput(file.toPath(), head.get("name"), head.get("category"), head.get("weight"), head.get("asset"), head.get("description")))
 						Logs.errLog("Concerned card file: " + file.getName());
 
 					if (!Databank.registerACard(cStruct))

--- a/src/main/java/com/is/mtc/displayer/DisplayerBlockRenderer.java
+++ b/src/main/java/com/is/mtc/displayer/DisplayerBlockRenderer.java
@@ -88,15 +88,10 @@ public class DisplayerBlockRenderer extends TileEntitySpecialRenderer<DisplayerB
 			CardItem cardItem = (CardItem) stack.getItem();
 			CardStructure cStruct = Databank.getCardByCDWD(stack.getTagCompound().getString("cdwd"));
 
-			if (cStruct == null || cStruct.getDynamicTexture() == null) { // Card not registered or unregistered illustration, use item image instead
+			if (cStruct == null || cStruct.getAssetLocation() == null) { // Card not registered or unregistered illustration, use item image instead
 				bindTexture(new ResourceLocation(Reference.MODID + ":textures/items/item_card_" + Rarity.toString(cardItem.getCardRarity()).toLowerCase() + ".png"));
 			} else {
-				cStruct.preloadResource(instance.renderEngine, stack.getTagCompound().getInteger("assetnumber"));
-				if (cStruct.getResourceLocation() != null) {
-					bindTexture(cStruct.getResourceLocation());
-				} else {
-					bindTexture(new ResourceLocation(Reference.MODID + ":textures/items/item_card_" + Rarity.toString(cardItem.getCardRarity()).toLowerCase() + ".png"));
-				}
+				bindTexture(cStruct.getAssetLocation());
 			}
 
 			tessellator.getBuffer().color(1f, 1f, 1f, 1f);

--- a/src/main/java/com/is/mtc/displayer_mono/MonoDisplayerBlockRenderer.java
+++ b/src/main/java/com/is/mtc/displayer_mono/MonoDisplayerBlockRenderer.java
@@ -80,15 +80,10 @@ public class MonoDisplayerBlockRenderer extends TileEntitySpecialRenderer<MonoDi
 			CardItem cardItem = (CardItem) stack.getItem();
 			CardStructure cStruct = Databank.getCardByCDWD(stack.getTagCompound().getString("cdwd"));
 
-			if (cStruct == null || cStruct.getDynamicTexture() == null) // Card not registered or unregistered illustration, use item image instead
+			if (cStruct == null || cStruct.getAssetLocation() == null) // Card not registered or unregistered illustration, use item image instead
 				bindTexture(new ResourceLocation(Reference.MODID, "textures/items/item_card_" + Rarity.toString(cardItem.getCardRarity()).toLowerCase() + ".png"));
 			else {
-				cStruct.preloadResource(instance.renderEngine, stack.getTagCompound().getInteger("assetnumber"));
-				if (cStruct.getResourceLocation() != null) {
-					bindTexture(cStruct.getResourceLocation());
-				} else {
-					bindTexture(new ResourceLocation(Reference.MODID, "textures/items/item_card_" + Rarity.toString(cardItem.getCardRarity()).toLowerCase() + ".png"));
-				}
+				bindTexture(cStruct.getAssetLocation());
 			}
 
 			tessellator.getBuffer().color(1f, 1f, 1f, 1f);

--- a/src/main/java/com/is/mtc/handler/GuiHandler.java
+++ b/src/main/java/com/is/mtc/handler/GuiHandler.java
@@ -71,7 +71,7 @@ public class GuiHandler implements IGuiHandler {
 				if (Tools.hasCDWD(stack)) {
 					CardStructure cStruct = Databank.getCardByCDWD(stack.getTagCompound().getString("cdwd"));
 
-					if (cStruct != null && cStruct.getDynamicTexture() != null) { // Card registered and dynamic texture (illustration) exists
+					if (cStruct != null && cStruct.getAssetLocation() != null) { // Card registered and dynamic texture (illustration) exists
 						return new CardItemInterface(stack);
 					} else {
 						Logs.chatMessage(player, "Unable to open card illustration: Missing client side illustration: " + stack.getTagCompound().getString("cdwd"));

--- a/src/main/java/com/is/mtc/pack/PackItemBase.java
+++ b/src/main/java/com/is/mtc/pack/PackItemBase.java
@@ -47,8 +47,6 @@ public class PackItemBase extends Item {
 
 		NBTTagCompound nbtTag = new NBTTagCompound();
 		nbtTag.setString("cdwd", cdwd); // Setting card
-		if (Databank.getCardByCDWD(cdwd).getAssetPath().size() > 0)
-			nbtTag.setInteger("assetnumber", Tools.randInt(0, Databank.getCardByCDWD(cdwd).getAssetPath().size(), world.rand));
 		genStack.setTagCompound(nbtTag);
 		spawnedEnt = new EntityItem(world, player.posX, player.posY + 1, player.posZ, genStack); // Spawning card
 

--- a/src/main/java/com/is/mtc/util/Reference.java
+++ b/src/main/java/com/is/mtc/util/Reference.java
@@ -4,7 +4,7 @@ import net.minecraft.util.text.TextFormatting;
 
 public class Reference {
 	public static final String MODID = "is_mtc";
-	public static final String MOD_VERSION = "@VERSION@";
+	public static final String MOD_VERSION = "3.1";
 	public static final String CONFIG_VERSION = "1.1";
 	public static final String NAME = "Mine Trading Cards";
 	public static final String NAME_COLORIZED = TextFormatting.BLUE+"Mine Trading Cards"+TextFormatting.RESET;

--- a/src/main/java/com/is/mtc/village/CardMasterHome.java
+++ b/src/main/java/com/is/mtc/village/CardMasterHome.java
@@ -444,8 +444,6 @@ public class CardMasterHome extends StructureVillagePieces.Village {
         			CardStructure cStruct = Databank.generateACard(cardIsUncommon ? Rarity.UNCOMMON : Rarity.COMMON, random);
         			if (cStruct != null) {
         				displaystack.setTagCompound(new NBTTagCompound());
-        				displaystack = CardItem.applyCDWDtoStack(displaystack, cStruct, random);
-        				
         				((DisplayerBlockTileEntity) te).setStackIntoSlot(displaystack, 0, false);
         			}
             	}

--- a/src/main/java/com/is/mtc/village/CardTrade.java
+++ b/src/main/java/com/is/mtc/village/CardTrade.java
@@ -80,7 +80,6 @@ public class CardTrade implements EntityVillager.ITradeList {
 		CardStructure cStruct = Databank.generateACard(((CardItem)stack.getItem()).getCardRarity(), random);
 		if (cStruct != null) {
 			stack.setTagCompound(new NBTTagCompound());
-			stack = CardItem.applyCDWDtoStack(stack, cStruct, random);
 		}
 		return stack;
 	}


### PR DESCRIPTION
(Greatly improved memory usage and performance) || Breaking Change!

This pull request changes the memory usage in my test case (7000~ cards at 700x700 res (roughly)) from 16GB (10GB for the cards) to 5 GB. Ive also noticed a great improvement on the load times, only taking a few seconds where it was 30s before.

Changes:
Made changes to the card loading to store a ResourceLocation instead of loading the texture during init. In order for this to have worked I needed to remove some code, and change quite a few files, as well as change the file structure that the mod uses. Card assets are now moved to the resourcepacks folder inside of a resourcepack. (I could also change it so that the entire mtc folder can be placed in the resource packs folder as well, if thats prefered). Because the card assets are now a resource pack, the folders inside of the pack can no longer have any uppercase letters. This, as well as having to move the card assets inside of "assets/is_mtc/textures/cards/" are the breaking changes for users. By default the mod will look for the cards at the same location as where the cfg files were stored (for example, cfg file is in "Trading card game/card_number_one.cfg", the mod will look for the card in "assets/is_mtc/textures/cards/trading card game/card_number_one.png"). If the card has an illustration path element, then that path is used instead (starting from "cards/").

Let me know if you would like me to move the entire mtc folder to the resource pack folder or if this is fine for now!